### PR TITLE
Fix memory leaks while running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const dbuz = @import("dbuz");
 pub fn main() !void {
     const allocator = std.heap.page_allocator;
 
-    /// Create connection to D-Bus session bus
+    // Create connection to D-Bus session bus
     const connection = try dbuz.connect(allocator, .{});
     defer connection.deinit();
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pub fn main() !void {
 
     std.posix.nanosleep(0, std.time.ns_per_ms * 25); // Sleep for some time to avoid busy loop
 
-    std.debug.print('My unique name is: {?s}\n', .{connection.unique_name});
+    std.debug.print("My unique name is: {?s}\n", .{connection.unique_name});
 }
 ```
 

--- a/src/types/DBusMessage.zig
+++ b/src/types/DBusMessage.zig
@@ -141,11 +141,7 @@ pub fn parseFromReader(allocator: std.mem.Allocator, bytes_reader: anytype, unix
     }
 
     var headers_list = try std.ArrayList(Header).initCapacity(allocator, 4);
-    var signature_buf = try ArrayListBuffer.initCapacity(allocator, 255);
-    errdefer {
-        headers_list.deinit(allocator);
-        signature_buf.deinit(allocator);
-    }
+    errdefer headers_list.deinit(allocator);
 
     var self: Self = .{ .allocator = allocator, .headers = headers_list };
 


### PR DESCRIPTION
I noticed that running 'zig build test' causes memory leaks. After some digging I found an unused variable and removing it solved the problem. I'm not sure what was it's purpose but I hope it wasn't important.

I also made readme example more copy-paste friendly

By the way, thanks for making this awesome library!